### PR TITLE
Fix HTTP errors due to too many open files

### DIFF
--- a/src/crawl.rs
+++ b/src/crawl.rs
@@ -10,6 +10,8 @@ use semver::Version;
 use std::collections::HashSet;
 use std::ops::Deref;
 use std::sync::Arc;
+use std::thread::sleep;
+use std::time::Duration;
 use tokio::sync::Mutex;
 
 #[derive(new)]
@@ -102,6 +104,10 @@ impl CrawlJob {
     }
 
     async fn fetch_instance_details(&self) -> Result<(NodeInfo, Option<GetSiteResponse>), Error> {
+        // Wait a little while to slow down the crawling and avoid too many open connections, which
+        // results in "error trying to connect: dns error: Too many open files".
+        sleep(Duration::from_millis(10));
+
         let rel_node_info: Url = Url::parse("http://nodeinfo.diaspora.software/ns/schema/2.0")
             .expect("parse nodeinfo relation url");
         let node_info_well_known = CLIENT


### PR DESCRIPTION
Was happening due to too many concurrent HTTP connections because the crawler is using recursion. With this 100ms sleep during each crawl it gives time for connections to be closed, and the problem is gone. Increases the number of crawled instances from `cargo run` from 9 to 30. In particular sopuli.xyz is now included.

Reported in https://lemmy.ml/post/903611

After merging this, the git submodule in joinlemmy-site repo needs to be updated, then the instance list should be updated automatically.