### PR TITLE
Dont follow redirects (fixes #8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,8 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.18.0"
+version = "0.18.1-rc.1"
+source = "git+https://github.com/LemmyNet/lemmy.git?branch=no-skip-serializing#02eecd2fd9654d0011707d8cdf9f15138faa0ae7"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1132,7 +1133,8 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.18.0"
+version = "0.18.1-rc.1"
+source = "git+https://github.com/LemmyNet/lemmy.git?branch=no-skip-serializing#02eecd2fd9654d0011707d8cdf9f15138faa0ae7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1148,11 +1150,13 @@ dependencies = [
  "tracing",
  "typed-builder",
  "url",
+ "uuid",
 ]
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.18.0"
+version = "0.18.1-rc.1"
+source = "git+https://github.com/LemmyNet/lemmy.git?branch=no-skip-serializing#02eecd2fd9654d0011707d8cdf9f15138faa0ae7"
 dependencies = [
  "lemmy_db_schema",
  "serde",
@@ -1162,7 +1166,8 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.18.0"
+version = "0.18.1-rc.1"
+source = "git+https://github.com/LemmyNet/lemmy.git?branch=no-skip-serializing#02eecd2fd9654d0011707d8cdf9f15138faa0ae7"
 dependencies = [
  "lemmy_db_schema",
  "serde",
@@ -1172,7 +1177,8 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.18.0"
+version = "0.18.1-rc.1"
+source = "git+https://github.com/LemmyNet/lemmy.git?branch=no-skip-serializing#02eecd2fd9654d0011707d8cdf9f15138faa0ae7"
 dependencies = [
  "lemmy_db_schema",
  "serde",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use semver::Version;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
+use reqwest::redirect::Policy;
 use tokio::sync::mpsc::{UnboundedReceiver, WeakUnboundedSender};
 use tokio::sync::{mpsc, Mutex};
 
@@ -24,6 +25,7 @@ static CLIENT: Lazy<Client> = Lazy::new(|| {
         .user_agent("lemmy-stats-crawler")
         .pool_idle_timeout(Some(Duration::from_millis(100)))
         .pool_max_idle_per_host(1)
+        .redirect(Policy::none())
         .build()
         .expect("build reqwest client")
 });


### PR DESCRIPTION
Im not actually sure if this fixes the problem. Its possible that some instances would list `lemmy.burger.rodeo` and others `burggit.moe` in their linked instances, so both might still be included in the output. 

Edit: This should be fine, when crawling the old domain it would immediately hit a redirect and abort.