### PR TITLE
Remove support for Lemmy 0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,6 @@ name = "anyhow"
 version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "async-trait"
@@ -702,8 +699,7 @@ dependencies = [
  "anyhow",
  "clap",
  "derive-new",
- "lemmy_api_common 0.18.5",
- "lemmy_api_common 0.19.0-rc.12",
+ "lemmy_api_common",
  "log",
  "once_cell",
  "regex",
@@ -719,33 +715,16 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.18.5"
-source = "git+https://github.com/LemmyNet/lemmy.git?tag=0.18.5#1846ae9e19e7a2d8eb275c3f6406770a552f5647"
-dependencies = [
- "anyhow",
- "getrandom",
- "lemmy_db_schema 0.18.5",
- "lemmy_db_views 0.18.5",
- "lemmy_db_views_actor 0.18.5",
- "lemmy_db_views_moderator 0.18.5",
- "regex",
- "serde",
- "serde_with",
- "url",
-]
-
-[[package]]
-name = "lemmy_api_common"
 version = "0.19.0-rc.12"
 source = "git+https://github.com/LemmyNet/lemmy.git?tag=0.19.0-rc.12#3f79eacb53c8a1bb0e23c4bd9037606a7cc58857"
 dependencies = [
  "chrono",
  "enum-map",
  "getrandom",
- "lemmy_db_schema 0.19.0-rc.12",
- "lemmy_db_views 0.19.0-rc.12",
- "lemmy_db_views_actor 0.19.0-rc.12",
- "lemmy_db_views_moderator 0.19.0-rc.12",
+ "lemmy_db_schema",
+ "lemmy_db_views",
+ "lemmy_db_views_actor",
+ "lemmy_db_views_moderator",
  "regex",
  "serde",
  "serde_with",
@@ -754,24 +733,6 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.18.5"
-source = "git+https://github.com/LemmyNet/lemmy.git?tag=0.18.5#1846ae9e19e7a2d8eb275c3f6406770a552f5647"
-dependencies = [
- "async-trait",
- "chrono",
- "futures-util",
- "serde",
- "serde_with",
- "strum",
- "strum_macros",
- "tracing",
- "typed-builder",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "lemmy_db_schema"
 version = "0.19.0-rc.12"
 source = "git+https://github.com/LemmyNet/lemmy.git?tag=0.19.0-rc.12#3f79eacb53c8a1bb0e23c4bd9037606a7cc58857"
 dependencies = [
@@ -790,34 +751,12 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.18.5"
-source = "git+https://github.com/LemmyNet/lemmy.git?tag=0.18.5#1846ae9e19e7a2d8eb275c3f6406770a552f5647"
-dependencies = [
- "lemmy_db_schema 0.18.5",
- "serde",
- "serde_with",
- "typed-builder",
-]
-
-[[package]]
-name = "lemmy_db_views"
 version = "0.19.0-rc.12"
 source = "git+https://github.com/LemmyNet/lemmy.git?tag=0.19.0-rc.12#3f79eacb53c8a1bb0e23c4bd9037606a7cc58857"
 dependencies = [
- "lemmy_db_schema 0.19.0-rc.12",
+ "lemmy_db_schema",
  "serde",
  "serde_with",
-]
-
-[[package]]
-name = "lemmy_db_views_actor"
-version = "0.18.5"
-source = "git+https://github.com/LemmyNet/lemmy.git?tag=0.18.5#1846ae9e19e7a2d8eb275c3f6406770a552f5647"
-dependencies = [
- "lemmy_db_schema 0.18.5",
- "serde",
- "serde_with",
- "typed-builder",
 ]
 
 [[package]]
@@ -826,7 +765,7 @@ version = "0.19.0-rc.12"
 source = "git+https://github.com/LemmyNet/lemmy.git?tag=0.19.0-rc.12#3f79eacb53c8a1bb0e23c4bd9037606a7cc58857"
 dependencies = [
  "chrono",
- "lemmy_db_schema 0.19.0-rc.12",
+ "lemmy_db_schema",
  "serde",
  "serde_with",
  "strum",
@@ -835,20 +774,10 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.18.5"
-source = "git+https://github.com/LemmyNet/lemmy.git?tag=0.18.5#1846ae9e19e7a2d8eb275c3f6406770a552f5647"
-dependencies = [
- "lemmy_db_schema 0.18.5",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "lemmy_db_views_moderator"
 version = "0.19.0-rc.12"
 source = "git+https://github.com/LemmyNet/lemmy.git?tag=0.19.0-rc.12#3f79eacb53c8a1bb0e23c4bd9037606a7cc58857"
 dependencies = [
- "lemmy_db_schema 0.19.0-rc.12",
+ "lemmy_db_schema",
  "serde",
  "serde_with",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ strip = "symbols"
 debug = 0
 
 [dependencies]
-lemmy_api_common_v018 = { package = "lemmy_api_common", git = "https://github.com/LemmyNet/lemmy.git", tag = "0.18.5" }
 lemmy_api_common_v019 = { package = "lemmy_api_common", git = "https://github.com/LemmyNet/lemmy.git", tag = "0.19.0-rc.12" }
 reqwest = { version = "0.11.23", default-features = false, features = [
   "json",

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,14 +1,7 @@
-use lemmy_api_common_v018::lemmy_db_schema::source::instance::Instance as Instance018;
-use lemmy_api_common_v018::site::{
-    GetFederatedInstancesResponse as GetFederatedInstancesResponse018,
-    GetSiteResponse as GetSiteResponse018,
-};
-use lemmy_api_common_v019::lemmy_db_schema::newtypes::InstanceId;
-use lemmy_api_common_v019::lemmy_db_schema::source::instance::Instance as Instance019;
 use lemmy_api_common_v019::site::{
     FederatedInstances as FederatedInstances019,
     GetFederatedInstancesResponse as GetFederatedInstancesResponse019,
-    GetSiteResponse as GetSiteResponse019, InstanceWithFederationState,
+    GetSiteResponse as GetSiteResponse019,
 };
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
@@ -50,63 +43,54 @@ pub struct NodeInfoUsers {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum GetSiteResponse {
-    V018(GetSiteResponse018),
     V019(GetSiteResponse019),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum GetFederatedInstancesResponse {
-    V018(GetFederatedInstancesResponse018),
     V019(GetFederatedInstancesResponse019),
 }
 
 impl GetSiteResponse {
     pub fn version(&self) -> String {
         match self {
-            GetSiteResponse::V018(s) => s.version.clone(),
             GetSiteResponse::V019(s) => s.version.clone(),
         }
     }
 
     pub fn total_users(&self) -> i64 {
         match self {
-            GetSiteResponse::V018(s) => s.site_view.counts.users,
             GetSiteResponse::V019(s) => s.site_view.counts.users,
         }
     }
 
     pub fn users_active_day(&self) -> i64 {
         match self {
-            GetSiteResponse::V018(s) => s.site_view.counts.users_active_day,
             GetSiteResponse::V019(s) => s.site_view.counts.users_active_day,
         }
     }
 
     pub fn users_active_week(&self) -> i64 {
         match self {
-            GetSiteResponse::V018(s) => s.site_view.counts.users_active_week,
             GetSiteResponse::V019(s) => s.site_view.counts.users_active_week,
         }
     }
 
     pub fn users_active_month(&self) -> i64 {
         match self {
-            GetSiteResponse::V018(s) => s.site_view.counts.users_active_month,
             GetSiteResponse::V019(s) => s.site_view.counts.users_active_month,
         }
     }
 
     pub fn users_active_half_year(&self) -> i64 {
         match self {
-            GetSiteResponse::V018(s) => s.site_view.counts.users_active_half_year,
             GetSiteResponse::V019(s) => s.site_view.counts.users_active_half_year,
         }
     }
 
     pub fn actor_id(&self) -> Url {
         match self {
-            GetSiteResponse::V018(s) => s.site_view.site.actor_id.inner().clone(),
             GetSiteResponse::V019(s) => s.site_view.site.actor_id.inner().clone(),
         }
     }
@@ -115,31 +99,7 @@ impl GetSiteResponse {
 impl GetFederatedInstancesResponse {
     pub fn federated_instances(&self) -> Option<FederatedInstances019> {
         match self {
-            GetFederatedInstancesResponse::V018(f) => {
-                f.federated_instances
-                    .as_ref()
-                    .map(|f| FederatedInstances019 {
-                        linked: f.linked.iter().map(convert_instance).collect(),
-                        allowed: vec![],
-                        blocked: vec![],
-                    })
-            }
             GetFederatedInstancesResponse::V019(f) => f.federated_instances.clone(),
         }
-    }
-}
-
-fn convert_instance(instance: &Instance018) -> InstanceWithFederationState {
-    InstanceWithFederationState {
-        instance: Instance019 {
-            // id field is private so we cant convert it
-            id: InstanceId::default(),
-            domain: instance.domain.clone(),
-            published: instance.published.clone().and_utc(),
-            updated: instance.updated.map(|u| u.and_utc()),
-            software: instance.software.clone(),
-            version: instance.version.clone(),
-        },
-        federation_state: None,
     }
 }


### PR DESCRIPTION
0.19 was published more than four months ago and most instances have already been upgraded. So its time to remove outdated instances.