### PR TITLE
Remove renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "schedule": ["every 3 months on the first day"],
-  "automerge": true
-}


### PR DESCRIPTION
This thing doesnt serve any real purpose, instead it creates unnecessary ci work and notifications. There is nothing wrong with having older dependency versions, if a newer version is really needed its much easier to upgrade manually.