### PR TITLE
Also show instances with captcha on join-lemmy

### DIFF
--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -1,5 +1,7 @@
 use chrono::{DateTime, Utc};
-use lemmy_api_common_v019::lemmy_db_views_actor::structs::CommunityView;
+use lemmy_api_common_v019::{
+    lemmy_db_schema::RegistrationMode, lemmy_db_views_actor::structs::CommunityView,
+};
 use serde::Serialize;
 
 use crate::crawl::CrawlResult;
@@ -121,12 +123,9 @@ pub fn joinlemmy_instance_data(
         // Filter out instances with other registration modes (closed dont allow signups and
         // open are often abused by bots)
         .filter(|i| {
-            &i.site_info
-                .site_view
-                .local_site
-                .registration_mode
-                .to_string()
-                == "RequireApplication"
+            let local_site = &i.site_info.site_view.local_site;
+            local_site.registration_mode == RegistrationMode::RequireApplication
+                || local_site.captcha_enabled
         })
         // Require at least 5 monthly users
         .filter(|i| i.site_info.site_view.counts.users_active_month > 5)


### PR DESCRIPTION
We previously only allowed instances with registration application enabled, because others may be full of spam bots. But I had a look at it and the ones with captcha look fine, no obvious spam bots. 

These are all added:
```
"sh.itjust.works",
"forum.guncadindex.com",
"lemmings.world",
"lemmy.org",
"ttrpg.network",
"lemmy.cafe",
"chatgptjailbreak.tech",
"fosscad.io",
"futurology.today",
"rekabu.ru",
"libretechni.ca",
"lemmy.neondystopia.world",
"welppp.com",
"hackerz.world",
"no.lastname.nz",
"lem.ugh.im",
"altgag.net",
"thinktank.brainstormes.org",
"civilloquy.com",
"linz.city",
"lemmy.imagisphe.re",
"lemmy.thefloatinglab.world",
"geekroom.tech",
"lemmy.laitinlok.com",
"lemmy.fediverse.jp",
"lemmy.thc.sh",
"lemmy.rhymelikedi.me",
"lemmy.corbin.sh",
"lemmy.perfecthluxury.store",
"szymbark.an0n.eu"
```